### PR TITLE
Fixed minor "bug" where stopAuto() doesn't work while carousel is animating

### DIFF
--- a/lib/jquery.jcarousel.js
+++ b/lib/jquery.jcarousel.js
@@ -451,7 +451,6 @@
             this.stopAuto();
 
             if (this.haltOnNext) {
-              console.log("I halted!");
               this.haltOnNext = false;
               return;
             }


### PR DESCRIPTION
Hi Jan,

I'm not sure if this is a "bug" or not, but I've updated the jcarousel so that stopAuto() works as expected (at least how _I_ expect it to work) when called while the carousel is animating.  Let me know what you think.

Thanks,
Brad
