### PR TITLE
Fixing resize issue with circular wrap

### DIFF
--- a/lib/jquery.jcarousel.js
+++ b/lib/jquery.jcarousel.js
@@ -272,6 +272,11 @@
             }
 
             if (this.options.visible !== null) {
+                if (this.options.wrap == 'circular' && this.first > this.options.size) {
+                    this.scroll(this.index(this.first), false);
+                    this.list.children('li:gt(' + this.options.size + ')').remove();
+                }
+
                 var self = this;
                 var di = Math.ceil(this.clipping() / this.options.visible), wh = 0, lt = 0;
                 this.list.children('li').each(function(i) {


### PR DESCRIPTION
I've used jCarousel in multiple web projects in the past and have been really happy with it. I ran into the circular resize bug as detailed in <a href="https://github.com/jsor/jcarousel/issues#issue/64">issue 64</a> and figured I'd try and contribute back. Anyways, I was running into dead ends trying to recalculate the size and figured out that, if the "first" element was larger than the options.size, you could use the scroll function to switch back to the original item (not the circular wrap generated one).

I've tested out the code in the site I'm currently building, as well as within some of the jCarousel example files, and it appears to be working without any problems. I haven't really tested it with any dynamic loading, but I believe it should respond similarly to the static loads. In a perfect world I'd probably want to have it recalculate the size properly and not do any jumps, but this seems to at least resolve the bug for the time being.

Thanks for all your work, and sorry if I've somehow done the pull request wonky (its my first).
