### PR TITLE
Add animationStepCallback option

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,6 +435,15 @@ itemVisibleOutCallback: {
 }</pre> </td>
       </tr>
       <tr>
+        <td>animationStepCallback</td>
+        <td>function</td>
+        <td>null</td>
+        <td>JavaScript function that is called after each animation step. This
+          function is directly passed to jQuery's <code>.animate()</code> method
+          as the <code>step</code> parameter. See the jQuery documentation for the
+          parameters it will receive.</td>
+      </tr>
+      <tr>
         <td>buttonNextCallback</td>
         <td>function</td>
         <td>null</td>

--- a/lib/jquery.jcarousel.js
+++ b/lib/jquery.jcarousel.js
@@ -37,6 +37,7 @@
         itemLastOutCallback: null,
         itemVisibleInCallback: null,
         itemVisibleOutCallback: null,
+        animationStepCallback: null,
         buttonNextHTML: '<div></div>',
         buttonPrevHTML: '<div></div>',
         buttonNextEvent: 'click',
@@ -739,7 +740,18 @@
                 scrolled();
             } else {
                 var o = !this.options.vertical ? (this.options.rtl ? {'right': p} : {'left': p}) : {'top': p};
-                this.list.animate(o, this.options.animation, this.options.easing, scrolled);
+                // Define animation settings.
+                var settings = {
+                    duration: this.options.animation,
+                    easing:   this.options.easing,
+                    complete: scrolled
+                };
+                // If we have a step callback, specify it as well.
+                if ($.isFunction(this.options.animationStepCallback)) {
+                    settings.step = this.options.animationStepCallback;
+                }
+                // Start the animation.
+                this.list.animate(o, settings);
             }
         },
 


### PR DESCRIPTION
This will be passed directly to jQuery’s `.animate()` function and thus
called after every animation step. Useful if you want to modify
additional things while the animation runs.

Please note that this commit does not update `jquery.jcarousel.min.js`
because I don’t have Jan’s minifier (and settings).
