### PR TITLE
Add "opts" function to get/set this.options values

### DIFF
--- a/lib/jquery.jcarousel.js
+++ b/lib/jquery.jcarousel.js
@@ -986,7 +986,7 @@
             }
 
             return Math.round((((i-1) / s) - Math.floor((i-1) / s)) * s) + 1;
-        }
+        },
 		opts: function(opt,val){
 			if(opt && val){
 				this.options[opt] = val;


### PR DESCRIPTION
I found this useful so I could read options and make my callbacks more customized.  E.g. There was no accessor for this.options.scroll value to do something for each visible item.

It is entirely possible that I was just missing how to access this.options from outside the class:

```
var scroll_size = jQuery('#mycarousel').jcarousel('opts','scroll');
var visible_size = jQuery('#mycarousel').jcarousel('opts','visible');
```

Please advise if this is helpful or if the functionality already exists and I'm missing something.

Thanks for the great lib.

Adam
