### PR TITLE
Return False to mouse events.

### DIFF
--- a/lib/jquery.jcarousel.js
+++ b/lib/jquery.jcarousel.js
@@ -175,8 +175,8 @@
         this.buttonNext.css('display', 'block');
         this.buttonPrev.css('display', 'block');
 
-        this.funcNext   = function() { self.next(); };
-        this.funcPrev   = function() { self.prev(); };
+        this.funcNext   = function() { self.next(); return false; };
+        this.funcPrev   = function() { self.prev(); return false; };
         this.funcResize = function() { 
             if (self.resizeTimer) {
                 clearTimeout(self.resizeTimer);


### PR DESCRIPTION
Added return false to mouse bound events to prevent the browser from jumping the page.
