### PR TITLE
Additional classes based on item position (odd/even, first/last)

### DIFF
--- a/lib/jquery.jcarousel.js
+++ b/lib/jquery.jcarousel.js
@@ -939,6 +939,7 @@
 
         format: function(e, i) {
             e = $(e);
+            var size = this.list.children('li').size();
             var split = e.get(0).className.split(' ');
             for (var j = 0; j < split.length; j++) {
                 if (split[j].indexOf('jcarousel-') != -1) {
@@ -949,6 +950,13 @@
                 'float': (this.options.rtl ? 'right' : 'left'),
                 'list-style': 'none'
             }).attr('jcarouselindex', i);
+            if (i === 1) {
+                e.addClass('jcarousel-item-first');
+            }
+            if (size === i) {
+                e.addClass('jcarousel-item-last');
+            }
+            e.addClass( i % 2 ? 'jcarousel-item-odd' : 'jcarousel-item-even');
             return e;
         },
 


### PR DESCRIPTION
I found it helpful to have these additional css classes so that styling the items can be done with more flexibility.

Classes include: .jcarousel-item-first, .jcarousel-item-last, .jcarousel-item-odd, and .jcarousel-item-even.

Also, when I get the size variable, I had originally tried using this.options.size, but for some reason it was returning null when using chrome (though it's obviously working in other parts of the code base).  I would love to get some insight on this.
