### PR TITLE
Fix the tail animation when using the "center" option (only LTR for now)

### DIFF
--- a/dist/jquery.jcarousel.js
+++ b/dist/jquery.jcarousel.js
@@ -630,7 +630,7 @@
             if (this.rtl) {
                 pos += this.tail;
             } else {
-                pos -= this.tail;
+                pos -= this.tail + ( this.options('center') ? ( this.clipping() / 2 ) - ( this.dimension( this._first ) / 2 ) : 0 );
             }
 
             this.inTail = true;
@@ -829,7 +829,7 @@
             }
 
             if ((this.index(item) > this.index(first) || this.inTail) && this.tail) {
-                pos = this.rtl ? pos - this.tail : pos + this.tail;
+                pos = this.rtl ? pos - this.tail : pos + this.tail + ( this.options('center') ? ( this.clipping() / 2 ) - (this.dimension(first) / 2) : 0 );
                 this.inTail = true;
             } else {
                 this.inTail = false;


### PR DESCRIPTION
I've noticed that the end animation with the center option enabled isn't animating as expected. An extra offset should be added to the tail when using the center option. I've applied and tested this only for the LTR animations.
