### PR TITLE
Ensure event handlers are triggered, not DOM functions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -154,7 +154,7 @@
                 (element || this._element).each(function() {
                     event = $.Event((pluginName + ':' + type).toLowerCase());
 
-                    $(this).trigger(event, data);
+                    $(this).triggerHandler(event, data);
 
                     if (event.isDefaultPrevented()) {
                         defaultPrevented = true;


### PR DESCRIPTION
Chrome 36 introduces a change that adds an `event.animate()` function to the DOM. The jQuery `trigger()` function will execute functions and not event handlers where a naming clash exists.

Changing the code to use the `jQuery triggerHandler()` function rather than `trigger()` ensures that event handlers are always fired as intended.
