### PR TITLE
make frame size higher level

### DIFF
--- a/examples/ajax/jcarousel.ajax.css
+++ b/examples/ajax/jcarousel.ajax.css
@@ -2,6 +2,11 @@
     margin: 20px auto;
     position: relative;
     border: 10px solid #fff;
+    /*
+    (4 * width: 150px) + (3 * margin-right: 1px) = 603px
+    */
+    width: 603px;
+    height: 100px;
     -webkit-border-radius: 5px;
     -moz-border-radius: 5px;
     border-radius: 5px;
@@ -15,11 +20,6 @@
 .jcarousel {
     position: relative;
     overflow: hidden;
-    /*
-    (4 * width: 150px) + (3 * margin-right: 1px) = 603px
-    */
-    width: 603px;
-    height: 100px;
 }
 
 .jcarousel ul {

--- a/examples/basic/jcarousel.basic.css
+++ b/examples/basic/jcarousel.basic.css
@@ -2,6 +2,8 @@
     margin: 20px auto;
     position: relative;
     border: 10px solid #fff;
+    width: 600px;
+    height: 400px;
     -webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;
@@ -30,8 +32,6 @@
 .jcarousel {
     position: relative;
     overflow: hidden;
-    width: 600px;
-    height: 400px;
 }
 
 .jcarousel ul {

--- a/examples/data-attributes/jcarousel.data-attributes.css
+++ b/examples/data-attributes/jcarousel.data-attributes.css
@@ -2,6 +2,8 @@
     margin: 20px auto;
     position: relative;
     border: 10px solid #fff;
+    width: 600px;
+    height: 400px;
     -webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;
@@ -30,8 +32,6 @@
 .jcarousel {
     position: relative;
     overflow: hidden;
-    width: 600px;
-    height: 400px;
 }
 
 .jcarousel ul {

--- a/examples/transitions/jcarousel.transitions.css
+++ b/examples/transitions/jcarousel.transitions.css
@@ -2,6 +2,8 @@
     margin: 20px auto;
     position: relative;
     border: 10px solid #fff;
+    width: 600px;
+    height: 400px;
     -webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;
@@ -29,8 +31,6 @@
 .jcarousel {
     position: relative;
     overflow: hidden;
-    width: 600px;
-    height: 400px;
 }
 
 .jcarousel ul {


### PR DESCRIPTION
If you shrink the sizes down from 600x400 to 300x200, then use a big screen and expand the browser, the jcarousel-wrapper actually stretches larger than the images. Moving the the size constraints to the jcarousel-wrapper to prevent the div growing larger than the image.
